### PR TITLE
Update ProcessPCH generated intermediate file extension to support Xcode 5 DP

### DIFF
--- a/oclint-xcodebuild
+++ b/oclint-xcodebuild
@@ -69,26 +69,28 @@ if os.path.isfile(XCODEBUILD_LOG_PATH):
             log_line = xcodebuild_log_file.readline()
             if not log_line:
                 break
-            process_pch_re = re.search("^ProcessPCH (.+)\.pch\.pth (.+)\.pch", log_line.strip())
+            process_pch_re = re.search("^ProcessPCH (.+)\.pch\.(pch|pth) (.+)\.pch", log_line.strip())
             if process_pch_re:
                 while 1:
                     log_line = xcodebuild_log_file.readline()
                     if not log_line:
                         break
+                    print log_line
                     working_directory_re = re.search("^cd (.+)", log_line.strip())
                     if working_directory_re:
-                        pch_dictionary[process_pch_re.group(1) + ".pch"] = working_directory_re.group(1) + "/" + process_pch_re.group(2) + ".pch"
+                        pch_dictionary[process_pch_re.group(1) + ".pch"] = working_directory_re.group(1) + "/" + process_pch_re.group(3) + ".pch"
                         break
             # below 11 lines of code are duplicated, serious refactoring is needed badly
-            process_pch_with_quote_re = re.search('^ProcessPCH "(.+)\.pch\.pth" "(.+)\.pch"', log_line.strip())
+            process_pch_with_quote_re = re.search('^ProcessPCH "(.+)\.pch\.(pch|pth)" "(.+)\.pch"', log_line.strip())
             if process_pch_with_quote_re:
                 while 1:
                     log_line = xcodebuild_log_file.readline()
                     if not log_line:
                         break
+                    print log_line
                     working_directory_with_quote_re = re.search('^cd "(.+)"', log_line.strip())
                     if working_directory_with_quote_re:
-                        pch_dictionary[process_pch_with_quote_re.group(1) + ".pch"] = working_directory_with_quote_re.group(1) + "/" + process_pch_with_quote_re.group(2) + ".pch"
+                        pch_dictionary[process_pch_with_quote_re.group(1) + ".pch"] = working_directory_with_quote_re.group(1) + "/" + process_pch_with_quote_re.group(3) + ".pch"
                         break
             source_compilation_setting_re = re.search("^CompileC", log_line.strip())
             if source_compilation_setting_re:


### PR DESCRIPTION
Having tried with Xcode 5 Developer Preview, and looks like Apple has changed the intermediate pch generation from '.pth' extension to '.pch' instead. For example, in the following section, search for '.pch.pch'.

This pull request is to solve this issue by supporting both '.pch' and '.pth' extensions in order to accommodate Xcode 5 DP and Xcode 4 users.

```
ProcessPCH /Users/lqi/Library/Developer/Xcode/DerivedData/ProjectName-cvncefyloqlfqlamzkxkzajraozj/Build/Intermediates/PrecompiledHeaders/ProjectName-Prefix-girwpdnhrqegmscnnegahagvdfdm/ProjectName-Prefix.pch.pch ProjectName/ProjectName-Prefix.pch normal armv7 objective-c com.apple.compilers.llvm.clang.1_0.compiler
    cd /Users/lqi/Projects/ClientName/ProjectName-ios
    setenv LANG en_US.US-ASCII
    setenv PATH "/Applications/Xcode5-DP.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin:/Applications/Xcode5-DP.app/Contents/Developer/usr/bin:/Users/lqi/Tools/apache-ant-1.9.0/bin:/Users/lqi/Tools/groovy-2.1.1/bin:/Users/lqi/Tools/gradle-1.4/bin:/Users/lqi/Tools/scala-2.10.1/bin:/Users/lqi/Tools/apache-maven-3.0.5/bin:/Users/lqi/Projects/LQRDG/oclint/build/oclint-release/bin:/Users/lqi/.rvm/gems/ruby-1.9.3-p327/bin:/Users/lqi/.rvm/gems/ruby-1.9.3-p327@global/bin:/Users/lqi/.rvm/rubies/ruby-1.9.3-p327/bin:/Users/lqi/.rvm/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
    /Applications/Xcode5-DP.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x objective-c-header -arch armv7 -fmessage-length=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit=0 -std=gnu99 -fobjc-arc -Wno-trigraphs -fpascal-strings -O0 -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-implicit-atomic-properties -Wno-receiver-is-weak -Wno-arc-repeated-use-of-weak -Wduplicate-method-match -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wunused-variable -Wunused-value -Wempty-body -Wuninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-shorten-64-to-32 -Wpointer-sign -Wno-newline-eof -Wno-selector -Wno-strict-selector-match -Wno-undeclared-selector -Wno-deprecated-implementations -DDEBUG=1 -isysroot /Applications/Xcode5-DP.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.0.sdk -fstrict-aliasing -Wprotocol -Wdeprecated-declarations -g -Wno-sign-conversion -miphoneos-version-min=6.0 -I/Users/lqi/Library/Developer/Xcode/DerivedData/ProjectName-cvncefyloqlfqlamzkxkzajraozj/Build/Intermediates/ProjectName.build/Debug-iphoneos/ProjectName.build/ProjectName.hmap -I/Users/lqi/Library/Developer/Xcode/DerivedData/ProjectName-cvncefyloqlfqlamzkxkzajraozj/Build/Products/Debug-iphoneos/include -I/Users/lqi/Projects/ClientName/ProjectName-ios/Pods/Headers -I/Users/lqi/Projects/ClientName/ProjectName-ios/Pods/Headers/AFNetworking -I/Users/lqi/Projects/ClientName/ProjectName-ios/Pods/Headers/SVProgressHUD -I/Users/lqi/Library/Developer/Xcode/DerivedData/ProjectName-cvncefyloqlfqlamzkxkzajraozj/Build/Intermediates/ProjectName.build/Debug-iphoneos/ProjectName.build/DerivedSources/armv7 -I/Users/lqi/Library/Developer/Xcode/DerivedData/ProjectName-cvncefyloqlfqlamzkxkzajraozj/Build/Intermediates/ProjectName.build/Debug-iphoneos/ProjectName.build/DerivedSources -F/Users/lqi/Library/Developer/Xcode/DerivedData/ProjectName-cvncefyloqlfqlamzkxkzajraozj/Build/Products/Debug-iphoneos --serialize-diagnostics /Users/lqi/Library/Developer/Xcode/DerivedData/ProjectName-cvncefyloqlfqlamzkxkzajraozj/Build/Intermediates/PrecompiledHeaders/ProjectName-Prefix-girwpdnhrqegmscnnegahagvdfdm/ProjectName-Prefix.pch.dia -MMD -MT dependencies -MF /Users/lqi/Library/Developer/Xcode/DerivedData/ProjectName-cvncefyloqlfqlamzkxkzajraozj/Build/Intermediates/PrecompiledHeaders/ProjectName-Prefix-girwpdnhrqegmscnnegahagvdfdm/ProjectName-Prefix.pch.d -c /Users/lqi/Projects/ClientName/ProjectName-ios/ProjectName/ProjectName-Prefix.pch -o /Users/lqi/Library/Developer/Xcode/DerivedData/ProjectName-cvncefyloqlfqlamzkxkzajraozj/Build/Intermediates/PrecompiledHeaders/ProjectName-Prefix-girwpdnhrqegmscnnegahagvdfdm/ProjectName-Prefix.pch.pch
```
