### PR TITLE
Change register_source_for_pth_file to include .h.pch suffix.

### DIFF
--- a/oclint-xcodebuild
+++ b/oclint-xcodebuild
@@ -78,7 +78,7 @@ def register_source_for_pth_file(clang_command, directory):
                 src_file = file
             elif tok == '-o':
                 file = tokens.next()
-                if file.endswith('.pch.pth') or file.endswith('.pch.pch'):
+                if file.endswith('.pch.pth') or file.endswith('.pch.pch') or file.endswith('.h.pch'):
                     pth_file = file
     except StopIteration:
         if src_file and pth_file:


### PR DESCRIPTION
We found that .h.pch suffix not being supported was the root cause of much of our troubles. By catching pre-compiled headers with this suffix we are now up and running. I suspect others will run into this too.
